### PR TITLE
Add MemoryModule persistence test

### DIFF
--- a/agents/alphagenius/memory/memory_module.py
+++ b/agents/alphagenius/memory/memory_module.py
@@ -112,5 +112,6 @@ if __name__ == '__main__':
     # new_memory.save_experiences() # Appends via add_experience, save_experiences overwrites
 
     print(f"Final experiences in new_memory: {len(new_memory.experiences)}")
-    if os.path.exists(mem_file): os.remove(mem_file)
-```
+    if os.path.exists(mem_file):
+        os.remove(mem_file)
+

--- a/agents/alphagenius/tests/test_memory_module.py
+++ b/agents/alphagenius/tests/test_memory_module.py
@@ -1,0 +1,41 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agents.alphagenius.memory.memory_module import MemoryModule
+
+
+def test_memory_module_persistence(tmp_path):
+    filepath = tmp_path / "mem.jsonl"
+    memory = MemoryModule(filepath=str(filepath))
+
+    memory.add_experience(
+        sub_goal="goal1",
+        script="script1",
+        stdout="output1",
+        stderr="",
+        fle_score=1.0,
+        novelty_score=0.5,
+        success=True,
+    )
+    memory.add_experience(
+        sub_goal="goal2",
+        script="script2",
+        stdout="output2",
+        stderr="error",
+        fle_score=0.0,
+        novelty_score=0.2,
+        success=False,
+    )
+
+    new_memory = MemoryModule()
+    loaded = new_memory.load_experiences(str(filepath))
+
+    assert loaded == 2
+    assert new_memory.experiences == memory.experiences
+
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 pythonpath = env/src
-testpaths = env/src/tests
+testpaths = env/tests agents/alphagenius/tests
 python_files = test_*.py


### PR DESCRIPTION
## Summary
- add persistence tests for `MemoryModule`
- include new test path in pytest config
- clean up stray backticks in `memory_module.py`

## Testing
- `pytest agents/alphagenius/tests/test_memory_module.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc68406d483338abaf71f3f02aa2c