### PR TITLE
Add environment abstraction and hierarchical planner

### DIFF
--- a/agents/alphagenius/alphagenius_agent.py
+++ b/agents/alphagenius/alphagenius_agent.py
@@ -4,7 +4,9 @@ import io
 import contextlib
 import traceback
 import asyncio
-import builtins # For mock execution fallback
+import builtins  # For mock execution fallback
+
+from .environment.base import EnvironmentBase
 
 try:
     from env.src.instance import FactorioInstance
@@ -108,8 +110,11 @@ REFLECTION_SYSTEM_PROMPT = (
     "Structure your response clearly, with the explanation first, then the corrected script (if any) or the suggestion."
 )
 
+from typing import Optional
+
+
 class AlphaGeniusAgent:
-    def __init__(self, config=None, environment=None, model_name: str = "gpt-4o-mini", agent_idx: int = 0):
+    def __init__(self, config=None, environment: Optional[EnvironmentBase] = None, model_name: str = "gpt-4o-mini", agent_idx: int = 0):
         # ... (self.config, self.environment, self.agent_idx setup)
         self.config = config; self.environment = environment; self.agent_idx = agent_idx
         

--- a/agents/alphagenius/environment/base.py
+++ b/agents/alphagenius/environment/base.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Tuple
+
+class EnvironmentBase(ABC):
+    """Abstract environment interface for AlphaGeniusAgent.
+
+    Different games or simulators should implement this interface so that
+    AlphaGeniusAgent can interact with them in a uniform way.
+    """
+
+    @abstractmethod
+    def eval(self, code: str, agent_idx: int = 0) -> Tuple[float, str, str]:
+        """Execute a Python program within the environment.
+
+        Args:
+            code: Python source code to execute.
+            agent_idx: Index of the agent, for multi-agent environments.
+
+        Returns:
+            A tuple ``(score, goal_description, result_str)`` representing the
+            environment specific score, the goal that was evaluated and the raw
+            result output (stdout/stderr combined) from execution.
+        """
+
+    @abstractmethod
+    def get_system_prompt(self, agent_idx: int = 0) -> str:
+        """Return an environment specific system prompt describing available tools."""
+
+    def reset(self) -> None:  # pragma: no cover - optional
+        """Reset the environment to its initial state."""
+        pass

--- a/agents/alphagenius/planning/__init__.py
+++ b/agents/alphagenius/planning/__init__.py
@@ -2,5 +2,6 @@
 # This file makes the 'planning' directory a Python package.
 
 from .planner import Planner
+from .hierarchical_planner import HierarchicalPlanner
 
-__all__ = ['Planner']
+__all__ = ['Planner', 'HierarchicalPlanner']

--- a/agents/alphagenius/planning/hierarchical_planner.py
+++ b/agents/alphagenius/planning/hierarchical_planner.py
@@ -1,0 +1,44 @@
+"""Simple hierarchical planner for AlphaGenius.
+
+This planner builds on the existing ``Planner`` class to recursively
+break down tasks. It stops decomposing when a sub-goal appears to
+match a skill provided in the :mod:`skill_library`.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from .planner import Planner
+from ..skill_library import __all__ as skill_list
+
+class HierarchicalPlanner:
+    """Recursively decompose tasks into executable sub-goals."""
+
+    def __init__(self, planner: Planner, max_depth: int = 2):
+        self.planner = planner
+        self.max_depth = max_depth
+        self.skill_names = set(skill_list)
+
+    async def plan(self, task: str, observation: str, depth: int | None = None) -> List[str]:
+        """Return a flat list of sub-goals for ``task``.
+
+        Args:
+            task: The high level goal to decompose.
+            observation: Current observation/context for the LLM planner.
+            depth: Optional recursion depth override.
+        """
+        if depth is None:
+            depth = self.max_depth
+        if depth <= 0:
+            return [task]
+
+        sub_goals = await self.planner.decompose_task(task, observation)
+        final_goals: List[str] = []
+        for sg in sub_goals:
+            # If sub-goal corresponds to a known skill we stop recursing
+            if any(name.replace('_', ' ') in sg.lower() for name in self.skill_names):
+                final_goals.append(sg)
+            else:
+                final_goals.extend(await self.plan(sg, observation, depth - 1))
+        return final_goals

--- a/agents/alphagenius/skill_library/__init__.py
+++ b/agents/alphagenius/skill_library/__init__.py
@@ -1,3 +1,8 @@
+"""Minimal skill library used by :class:`AlphaGeniusAgent`."""
+
+__all__ = ["greet"]
+
+
 def greet():
     """A simple example skill that greets the user."""
     print("hello")

--- a/docs/environment_registration.md
+++ b/docs/environment_registration.md
@@ -1,0 +1,34 @@
+# Registering a Custom Environment for AlphaGenius
+
+`AlphaGeniusAgent` interacts with its world though objects that implement the
+`EnvironmentBase` interface. This allows the agent to be reused in different
+games or simulations.
+
+1. **Implement the interface**
+
+   Create a subclass of `EnvironmentBase` and provide implementations for
+   `eval()` and `get_system_prompt()`. Optionally override `reset()`.
+
+   ```python
+   from agents.alphagenius.environment.base import EnvironmentBase
+
+   class ChessEnv(EnvironmentBase):
+       def eval(self, code: str, agent_idx: int = 0):
+           # Execute `code` inside the chess simulator
+           ...
+           return score, "move piece", output
+
+       def get_system_prompt(self, agent_idx: int = 0) -> str:
+           return "Documentation for the chess API"
+   ```
+
+2. **Create the agent with your environment**
+
+   ```python
+   from agents.alphagenius.alphagenius_agent import AlphaGeniusAgent
+   env = ChessEnv()
+   agent = AlphaGeniusAgent(environment=env)
+   ```
+
+The agent will automatically use the system prompt and `eval` method of your
+environment when generating and executing code.


### PR DESCRIPTION
## Summary
- add abstract EnvironmentBase to allow plugging in custom worlds
- expose new HierarchicalPlanner for recursive sub-goal generation
- register HierarchicalPlanner in the planning package
- track available skills via `__all__`
- document how to register custom environments
- update AlphaGeniusAgent to accept any EnvironmentBase

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_683fcabda45c83339b96b17c0f3afc97